### PR TITLE
Avoid decimal divide by zero error when calculating pricePerUnit

### DIFF
--- a/rules/ehf-creditnote-2.0/sch/NONAT-UBL-T14.sch
+++ b/rules/ehf-creditnote-2.0/sch/NONAT-UBL-T14.sch
@@ -101,6 +101,7 @@
          <let name="sumCharge" value="sum(cac:AllowanceCharge[child::cbc:ChargeIndicator='true']/cbc:Amount)" />
          <let name="sumAllowance" value="sum(cac:AllowanceCharge[child::cbc:ChargeIndicator='false']/cbc:Amount)"/>
          <let name="baseQuantity" value="xs:decimal(if (cac:Price/cbc:BaseQuantity) then cac:Price/cbc:BaseQuantity else 1)"/>
+         <let name="baseQuantity" value="xs:decimal(if (cac:Price/cbc:BaseQuantity) then (if (cac:Price/cbc:BaseQuantity &lt;= 0) then (1) else (cac:Price/cbc:BaseQuantity)) else 1)"/>
          <let name="pricePerUnit" value="xs:decimal(cac:Price/cbc:PriceAmount) div $baseQuantity"/>
          <let name="quantity" value="xs:decimal(cbc:CreditedQuantity)"/>
          <let name="lineExtensionAmount" value="number(cbc:LineExtensionAmount)"/>

--- a/rules/ehf-creditnote-2.0/sch/NONAT-UBL-T14.sch
+++ b/rules/ehf-creditnote-2.0/sch/NONAT-UBL-T14.sch
@@ -100,8 +100,7 @@
       <rule context="cac:CreditNoteLine">
          <let name="sumCharge" value="sum(cac:AllowanceCharge[child::cbc:ChargeIndicator='true']/cbc:Amount)" />
          <let name="sumAllowance" value="sum(cac:AllowanceCharge[child::cbc:ChargeIndicator='false']/cbc:Amount)"/>
-         <let name="baseQuantity" value="xs:decimal(if (cac:Price/cbc:BaseQuantity) then cac:Price/cbc:BaseQuantity else 1)"/>
-         <let name="baseQuantity" value="xs:decimal(if (cac:Price/cbc:BaseQuantity) then (if (cac:Price/cbc:BaseQuantity &lt;= 0) then (1) else (cac:Price/cbc:BaseQuantity)) else 1)"/>
+         <let name="baseQuantity" value="xs:decimal(if (cac:Price/cbc:BaseQuantity and xs:decimal(cac:Price/cbc:BaseQuantity) != 0) then cac:Price/cbc:BaseQuantity else 1)"/>
          <let name="pricePerUnit" value="xs:decimal(cac:Price/cbc:PriceAmount) div $baseQuantity"/>
          <let name="quantity" value="xs:decimal(cbc:CreditedQuantity)"/>
          <let name="lineExtensionAmount" value="number(cbc:LineExtensionAmount)"/>

--- a/rules/ehf-invoice-2.0/sch/NONAT-UBL-T10.sch
+++ b/rules/ehf-invoice-2.0/sch/NONAT-UBL-T10.sch
@@ -104,7 +104,7 @@
       <rule context="cac:InvoiceLine">
          <let name="sumCharge" value="sum(cac:AllowanceCharge[child::cbc:ChargeIndicator='true']/cbc:Amount)" />
          <let name="sumAllowance" value="sum(cac:AllowanceCharge[child::cbc:ChargeIndicator='false']/cbc:Amount)"/>
-         <let name="baseQuantity" value="xs:decimal(if (cac:Price/cbc:BaseQuantity) then cac:Price/cbc:BaseQuantity else 1)"/>
+         <let name="baseQuantity" value="xs:decimal(if (cac:Price/cbc:BaseQuantity) then (if (cac:Price/cbc:BaseQuantity &lt;= 0) then (1) else (cac:Price/cbc:BaseQuantity)) else 1)"/>
          <let name="pricePerUnit" value="xs:decimal(cac:Price/cbc:PriceAmount) div $baseQuantity"/>
          <let name="quantity" value="xs:decimal(cbc:InvoicedQuantity)"/>
          <let name="lineExtensionAmount" value="number(cbc:LineExtensionAmount)"/>

--- a/rules/ehf-invoice-2.0/sch/NONAT-UBL-T10.sch
+++ b/rules/ehf-invoice-2.0/sch/NONAT-UBL-T10.sch
@@ -104,7 +104,7 @@
       <rule context="cac:InvoiceLine">
          <let name="sumCharge" value="sum(cac:AllowanceCharge[child::cbc:ChargeIndicator='true']/cbc:Amount)" />
          <let name="sumAllowance" value="sum(cac:AllowanceCharge[child::cbc:ChargeIndicator='false']/cbc:Amount)"/>
-         <let name="baseQuantity" value="xs:decimal(if (cac:Price/cbc:BaseQuantity) then (if (cac:Price/cbc:BaseQuantity &lt;= 0) then (1) else (cac:Price/cbc:BaseQuantity)) else 1)"/>
+         <let name="baseQuantity" value="xs:decimal(if (cac:Price/cbc:BaseQuantity and xs:decimal(cac:Price/cbc:BaseQuantity) != 0) then cac:Price/cbc:BaseQuantity else 1)"/>
          <let name="pricePerUnit" value="xs:decimal(cac:Price/cbc:PriceAmount) div $baseQuantity"/>
          <let name="quantity" value="xs:decimal(cbc:InvoicedQuantity)"/>
          <let name="lineExtensionAmount" value="number(cbc:LineExtensionAmount)"/>


### PR DESCRIPTION
While testing upcoming artifacts release I noticed that NONAT-T10-R033 and NONAT-T14-R033 fire SYSTEM-008 (Unable to perform check: Decimal divide by zero). This issue can be reproduced with https://test-vefa.difi.no/validator/

Example invoice line:

```
<cac:InvoiceLine>
  <cbc:ID>1</cbc:ID>
  <cbc:InvoicedQuantity unitCode="NAR" unitCodeListID="UNECERec20">1.00</cbc:InvoicedQuantity>
  <cbc:LineExtensionAmount currencyID="NOK">100.00</cbc:LineExtensionAmount>
  <cbc:AccountingCost>BookingCode001</cbc:AccountingCost>
  <cac:OrderLineReference>
    <cbc:LineID>1</cbc:LineID>
  </cac:OrderLineReference>
  <cac:TaxTotal>
    <cbc:TaxAmount currencyID="NOK">25.00</cbc:TaxAmount>
  </cac:TaxTotal>
  <cac:Item>
    <cbc:Name>Item</cbc:Name>
    <cac:SellersItemIdentification>
      <cbc:ID>ID0001</cbc:ID>
    </cac:SellersItemIdentification>
    <cac:ClassifiedTaxCategory>
      <cbc:ID schemeID="UNCL5305">S</cbc:ID>
      <cbc:Percent>25.00</cbc:Percent>
      <cac:TaxScheme>
        <cbc:ID schemeID="UN/ECE 5153">VAT</cbc:ID>
      </cac:TaxScheme>
    </cac:ClassifiedTaxCategory>
  </cac:Item>
  <cac:Price>
    <cbc:PriceAmount currencyID="NOK">100.00</cbc:PriceAmount>
    <cbc:BaseQuantity>0</cbc:BaseQuantity>
  </cac:Price>
</cac:InvoiceLine>
```
The problem seems to be generated from here in NONAT-UBL-T10.sch:

```
<xsl:variable name="baseQuantity"
              select="xs:decimal(if (cac:Price/cbc:BaseQuantity) then cac:Price/cbc:BaseQuantity else 1)"/>
<xsl:variable name="pricePerUnit"
              select="xs:decimal(cac:Price/cbc:PriceAmount) div $baseQuantity"/>
```
